### PR TITLE
Depend on fixed libintl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.gnu.gettext</groupId>
 			<artifactId>libintl</artifactId>
-			<version>0.18.2</version>
+			<version>0.18.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
I saw there was a fixed pom, but that we don't depend on that yet.