### PR TITLE
Fix use of format specifiers in logger calls

### DIFF
--- a/src/main/java/com/teamunify/i18n/I.java
+++ b/src/main/java/com/teamunify/i18n/I.java
@@ -914,7 +914,7 @@ public final class I {
         amount = amount.replace(" ", "\u00a0");
       return fmt.parse(amount);
     } catch (ParseException e) {
-      log.debug("Failed to parse currency: " + amount, e);
+      log.debug("Failed to parse currency: {}", amount, e);
     }
     return defaultValue;
   }

--- a/src/main/java/com/teamunify/i18n/I.java
+++ b/src/main/java/com/teamunify/i18n/I.java
@@ -618,8 +618,8 @@ public final class I {
     }
 
     if (log.isDebugEnabled())
-      log.debug(String.format("Failed to parse date >%s< when using language settings for %s", source,
-                              s.locale.getLanguage()), e);
+      log.debug("Failed to parse date >{}< when using language settings for {}",
+			  source, s.locale.getLanguage(), e);
 
     return rv;
   }

--- a/src/main/java/com/teamunify/i18n/settings/LanguageSetting.java
+++ b/src/main/java/com/teamunify/i18n/settings/LanguageSetting.java
@@ -67,7 +67,7 @@ public final class LanguageSetting {
     try {
       return (ResourceBundle) Class.forName(fqcn).newInstance();
     } catch (Exception e) {
-      log.warn(String.format("Could not find resource bundle: %s.", fqcn));
+      log.warn("Could not find resource bundle: {}.", fqcn);
     }
     return null;
   }
@@ -90,7 +90,7 @@ public final class LanguageSetting {
 
     if (rv != null) {
       if (log.isDebugEnabled())
-        log.debug(String.format("Using preloaded %s for %s", rv.getClass().getSimpleName(), key));
+        log.debug("Using preloaded {} for {}", rv.getClass().getSimpleName(), key);
       return rv;
     }
 
@@ -108,7 +108,7 @@ public final class LanguageSetting {
     } finally {
       if (rv != null) {
         if (log.isDebugEnabled())
-          log.debug(String.format("Saving bundle %s for %s", rv.getClass().getSimpleName(), key));
+          log.debug("Saving bundle {} for {}", rv.getClass().getSimpleName(), key);
         translations.put(key, rv);
       }
     }

--- a/src/main/java/com/teamunify/i18n/settings/ThreadLocalLanguageSettingsProvider.java
+++ b/src/main/java/com/teamunify/i18n/settings/ThreadLocalLanguageSettingsProvider.java
@@ -25,7 +25,7 @@ public class ThreadLocalLanguageSettingsProvider implements LanguageSettingsProv
 
   public void setLocale(Locale l) {
     LanguageSetting setting = new LanguageSetting(l);
-    log.debug("setting language bundle to " + setting.translation.getClass().getName());
+    log.debug("Setting language bundle to {}", setting.translation.getClass().getName());
     currentLanguage.set(setting);
   }
 }


### PR DESCRIPTION
This way the strings are not formatted eagerly
(Note that the trailing Throwable in the 'formatting arguments' will be picked up as the exception of the log)